### PR TITLE
Add offline-first service worker for PWA

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,8 +45,8 @@
   .chip{display:inline-block;background:#1b1b20;border:1px solid #2a2a30;border-radius:999px;padding:6px 10px;font-size:12px;margin-right:6px}
 </style>
 <!-- External libs -->
-<script src="https://unpkg.com/tesseract.js@5/dist/tesseract.min.js"></script>
-<script src="https://unpkg.com/quagga@0.12.1/dist/quagga.min.js"></script>
+<script src="https://unpkg.com/tesseract.js@5/dist/tesseract.min.js" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/quagga@0.12.1/dist/quagga.min.js" crossorigin="anonymous"></script>
 </head>
 <body>
 <header>
@@ -841,12 +841,7 @@ function setupPWA(){
   document.getElementById('app-manifest').setAttribute('href', url);
 
   if('serviceWorker' in navigator){
-    const swCode = `self.addEventListener('install',e=>{self.skipWaiting();});
-self.addEventListener('activate',e=>{clients.claim();});
-self.addEventListener('fetch',e=>{e.respondWith(fetch(e.request).catch(()=>caches.match('offline')))});`;
-    const swBlob = new Blob([swCode], {type:'text/javascript'});
-    const swUrl = URL.createObjectURL(swBlob);
-    navigator.serviceWorker.register(swUrl).catch(()=>{});
+    navigator.serviceWorker.register('sw.js').catch(()=>{});
   }
 }
 

--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Нет подключения • Eato Budget</title>
+  <style>
+    body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;background:#0d0d0f;color:#f2f2f7;padding:20px;text-align:center}
+    main{max-width:360px}
+    h1{font-size:22px;margin-bottom:12px}
+    p{color:#a1a1aa;font-size:15px;line-height:1.5}
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Оффлайн режим</h1>
+    <p>Нет подключения к сети. Продолжайте пользоваться уже сохранёнными данными. Как только связь восстановится, приложение обновит данные автоматически.</p>
+  </main>
+</body>
+</html>

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,75 @@
+const CACHE_NAME = 'eato-v2';
+const STATIC_ASSETS = [
+  './',
+  '/',
+  '/index.html',
+  '/offline.html',
+  'https://unpkg.com/tesseract.js@5/dist/tesseract.min.js',
+  'https://unpkg.com/quagga@0.12.1/dist/quagga.min.js'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(STATIC_ASSETS)).then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(keys.filter(name => name !== CACHE_NAME).map(name => caches.delete(name))))
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  const requestURL = new URL(event.request.url);
+  const isSameOrigin = requestURL.origin === self.location.origin;
+  const isStaticAsset = STATIC_ASSETS.some(asset => {
+    try {
+      const assetURL = new URL(asset, self.location.origin);
+      return assetURL.href === requestURL.href;
+    } catch (err) {
+      return asset === event.request.url;
+    }
+  });
+
+  if (isStaticAsset) {
+    event.respondWith(
+      caches.match(event.request, { ignoreSearch: true }).then(cached => {
+        if (cached) {
+          return cached;
+        }
+        return fetch(event.request).then(response => {
+          const responseClone = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(event.request, responseClone));
+          return response;
+        });
+      })
+    );
+    return;
+  }
+
+  event.respondWith(
+    fetch(event.request).then(response => {
+      if (isSameOrigin && response && response.status === 200) {
+        const copy = response.clone();
+        caches.open(CACHE_NAME).then(cache => cache.put(event.request, copy));
+      }
+      return response;
+    }).catch(() => {
+      return caches.match(event.request).then(match => {
+        if (match) {
+          return match;
+        }
+        if (event.request.mode === 'navigate') {
+          return caches.match('/offline.html');
+        }
+        return Response.error();
+      });
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- add a dedicated service worker that precaches core assets, uses cache-first for libraries, and network-first with offline fallback for dynamic requests
- register the service worker during PWA setup and provide an offline fallback page for navigation failures

## Testing
- not run (environment lacks browser/PWA runtime)


------
https://chatgpt.com/codex/tasks/task_e_68d6a74fc26483218d788a93c75cdfd6