### PR TITLE
Fetch OpenFoodFacts nutrition when scanning barcodes

### DIFF
--- a/index.html
+++ b/index.html
@@ -443,6 +443,50 @@ let barcodeLookupInFlight = false;
 let barcodeProcessedHandler = null;
 let barcodeDetectedHandler = null;
 
+function normaliseNumber(value){
+  if(value == null) return null;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function setFormField(selector, value){
+  const el = $(selector);
+  if(!el) return;
+  el.value = value == null ? '' : String(value);
+}
+
+function populateAddFoodFormFromProduct(product, code){
+  const nutriments = product?.nutriments || {};
+  const nameBase = product?.product_name || product?.generic_name || product?.brands || 'Продукт';
+  setFormField('#add-name', `${nameBase} (EAN ${code})`);
+
+  const kcal = normaliseNumber(
+    nutriments['energy-kcal_100g'] ??
+    nutriments['energy-kcal'] ??
+    (function(){
+      const kj = normaliseNumber(nutriments['energy-kj_100g'] ?? nutriments['energy-kj']);
+      return kj == null ? null : Math.round(kj / 4.184);
+    })()
+  );
+  const protein = normaliseNumber(nutriments['proteins_100g']);
+  const fat = normaliseNumber(nutriments['fat_100g']);
+  const carbs = normaliseNumber(nutriments['carbohydrates_100g']);
+
+  setFormField('#add-kcal', kcal != null ? Math.round(kcal) : null);
+  const round1 = v => (v == null ? null : Math.round(v * 10) / 10);
+  setFormField('#add-p', round1(protein));
+  setFormField('#add-f', round1(fat));
+  setFormField('#add-c', round1(carbs));
+}
+
+function prepareAddFoodFormForManualEntry(code){
+  setFormField('#add-name', `Продукт (EAN ${code})`);
+  setFormField('#add-kcal', null);
+  setFormField('#add-p', null);
+  setFormField('#add-f', null);
+  setFormField('#add-c', null);
+}
+
 function startBarcode(){
   if(!window.Quagga){ toast('QuaggaJS не загрузился', true); return; }
   if(quaggaRunning){ toast('Сканирование уже идёт'); return; }
@@ -482,29 +526,15 @@ function startBarcode(){
       const payload = await response.json();
       const product = payload?.status === 1 ? payload.product : null;
       if(product){
-        const nutriments = product.nutriments || {};
-        const nameBase = product.product_name || product.generic_name || product.brands || 'Продукт';
-        const formName = `${nameBase} (EAN ${code})`;
-        const setValue = (selector, value, formatter = v => v) => {
-          const el = $(selector);
-          if(!el) return;
-          const num = Number(value);
-          if(Number.isFinite(num)){
-            el.value = String(formatter(num));
-          }
-        };
-
-        $('#add-name').value = formName;
-        setValue('#add-kcal', nutriments['energy-kcal_100g'], Math.round);
-        setValue('#add-p', nutriments['proteins_100g']);
-        setValue('#add-f', nutriments['fat_100g']);
-        setValue('#add-c', nutriments['carbohydrates_100g']);
+        populateAddFoodFormFromProduct(product, code);
         toast('Данные подставлены из OpenFoodFacts');
       }else{
+        prepareAddFoodFormForManualEntry(code);
         toast('Продукт не найден в OpenFoodFacts. Введите данные вручную.');
       }
     }catch(err){
       console.error('Ошибка загрузки данных продукта', err);
+      prepareAddFoodFormForManualEntry(code);
       toast('Не удалось получить данные продукта. Попробуйте позже.', true);
     }finally{
       barcodeLookupInFlight = false;

--- a/index.html
+++ b/index.html
@@ -440,9 +440,13 @@ function parseLabelText(rawText){
 // ---------- Barcode (Quagga) ----------
 let quaggaRunning = false;
 let barcodeLookupInFlight = false;
+let barcodeProcessedHandler = null;
+let barcodeDetectedHandler = null;
 
 function startBarcode(){
   if(!window.Quagga){ toast('QuaggaJS не загрузился', true); return; }
+  if(quaggaRunning){ toast('Сканирование уже идёт'); return; }
+
   const container = document.getElementById('barcode-area');
   if(!container){ toast('Не найден контейнер камеры', true); return; }
 
@@ -452,53 +456,21 @@ function startBarcode(){
 
   // Clean container
   container.innerHTML = '';
+  container.style.boxShadow = "none";
 
   const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
 
-  Quagga.init({
-    inputStream: {
-      type: "LiveStream",
-      target: container,                // Quagga will inject its own <video> here
-      constraints: {
-        facingMode: "environment",
-        width: { ideal: 1280 },
-        height: { ideal: 720 }
-      }
-    },
-    locator: { patchSize: "medium", halfSample: true },
-    numOfWorkers: isIOS ? 0 : 2,        // iOS Safari needs 0
-    frequency: 10,
-    locate: true,
-    decoder: { readers: ["ean_reader","ean_8_reader","upc_reader","upc_e_reader"] }
-  }, function(err){
-    if (err) { console.log(err); toast('Камера недоступна: ' + err.message, true); return; }
-    Quagga.start(); 
-    window.__quaggaRunning = true;
-    toast('Сканирование запущено');
-  });
+  barcodeLookupInFlight = false;
 
-  // Visual feedback (optional)
-  Quagga.onProcessed(function(result) {
-    // Add simple overlay by toggling background if no result
+  barcodeProcessedHandler = function(result){
     if(!result || !result.boxes || result.boxes.length===0){
       container.style.boxShadow = "inset 0 0 0 2px rgba(255,255,255,.1)";
     }else{
       container.style.boxShadow = "inset 0 0 0 2px rgba(45,212,191,.4)";
     }
-  });
+  };
 
-  // Detection handler is defined elsewhere (onDetected)
-}
-
-  const videoEl = $('#barcode-video');
-  Quagga.init({
-    inputStream: { type: "LiveStream", target: videoEl, constraints:{ facingMode:"environment" } },
-    decoder: { readers: ["ean_reader","ean_8_reader","upc_reader","upc_e_reader"] }
-  }, function(err){
-    if (err) { console.log(err); toast('Камера недоступна', true); return; }
-    Quagga.start(); quaggaRunning = true; toast('Сканирование запущено');
-  });
-  Quagga.onDetected(async data=>{
+  barcodeDetectedHandler = async function(data){
     const code = data?.codeResult?.code;
     if(!code || barcodeLookupInFlight){ return; }
     barcodeLookupInFlight = true;
@@ -538,17 +510,64 @@ function startBarcode(){
       barcodeLookupInFlight = false;
       stopBarcode();
     }
+  };
+
+  Quagga.init({
+    inputStream: {
+      type: "LiveStream",
+      target: container,                // Quagga will inject its own <video> here
+      constraints: {
+        facingMode: "environment",
+        width: { ideal: 1280 },
+        height: { ideal: 720 }
+      }
+    },
+    locator: { patchSize: "medium", halfSample: true },
+    numOfWorkers: isIOS ? 0 : 2,        // iOS Safari needs 0
+    frequency: 10,
+    locate: true,
+    decoder: { readers: ["ean_reader","ean_8_reader","upc_reader","upc_e_reader"] }
+  }, function(err){
+    if (err) {
+      console.log(err);
+      toast('Камера недоступна: ' + err.message, true);
+      barcodeProcessedHandler = null;
+      barcodeDetectedHandler = null;
+      return;
+    }
+
+    Quagga.onProcessed(barcodeProcessedHandler);
+    Quagga.onDetected(barcodeDetectedHandler);
+
+    Quagga.start();
+    quaggaRunning = true;
+    window.__quaggaRunning = true;
+    toast('Сканирование запущено');
   });
 }
 
 function stopBarcode(){
+  if(barcodeLookupInFlight){
+    toast('Ждём данные продукта...', true);
+    return;
+  }
+
   try{
-    if(window.Quagga && window.__quaggaRunning){
-      Quagga.offProcessed && Quagga.offProcessed();
-      Quagga.offDetected && Quagga.offDetected();
+    if(window.Quagga && quaggaRunning){
+      if(barcodeProcessedHandler){
+        Quagga.offProcessed && Quagga.offProcessed(barcodeProcessedHandler);
+      }
+      if(barcodeDetectedHandler){
+        Quagga.offDetected && Quagga.offDetected(barcodeDetectedHandler);
+      }
+      barcodeProcessedHandler = null;
+      barcodeDetectedHandler = null;
+
       Quagga.stop();
+      quaggaRunning = false;
       window.__quaggaRunning = false;
     }
+    barcodeLookupInFlight = false;
     const container = document.getElementById('barcode-area');
     if(container) container.style.boxShadow = "none";
     toast('Сканирование остановлено');

--- a/index.html
+++ b/index.html
@@ -439,6 +439,7 @@ function parseLabelText(rawText){
 
 // ---------- Barcode (Quagga) ----------
 let quaggaRunning = false;
+let barcodeLookupInFlight = false;
 
 function startBarcode(){
   if(!window.Quagga){ toast('QuaggaJS не загрузился', true); return; }
@@ -497,11 +498,44 @@ function startBarcode(){
     if (err) { console.log(err); toast('Камера недоступна', true); return; }
     Quagga.start(); quaggaRunning = true; toast('Сканирование запущено');
   });
-  Quagga.onDetected(data=>{
+  Quagga.onDetected(async data=>{
     const code = data?.codeResult?.code;
-    if(code){
-      $('#barcode-out').textContent = code;
-      // Stop after first good scan to avoid duplicates
+    if(!code || barcodeLookupInFlight){ return; }
+    barcodeLookupInFlight = true;
+    $('#barcode-out').textContent = code;
+
+    try{
+      const response = await fetch(`https://world.openfoodfacts.org/api/v2/product/${code}.json`);
+      if(!response.ok){ throw new Error(`HTTP ${response.status}`); }
+      const payload = await response.json();
+      const product = payload?.status === 1 ? payload.product : null;
+      if(product){
+        const nutriments = product.nutriments || {};
+        const nameBase = product.product_name || product.generic_name || product.brands || 'Продукт';
+        const formName = `${nameBase} (EAN ${code})`;
+        const setValue = (selector, value, formatter = v => v) => {
+          const el = $(selector);
+          if(!el) return;
+          const num = Number(value);
+          if(Number.isFinite(num)){
+            el.value = String(formatter(num));
+          }
+        };
+
+        $('#add-name').value = formName;
+        setValue('#add-kcal', nutriments['energy-kcal_100g'], Math.round);
+        setValue('#add-p', nutriments['proteins_100g']);
+        setValue('#add-f', nutriments['fat_100g']);
+        setValue('#add-c', nutriments['carbohydrates_100g']);
+        toast('Данные подставлены из OpenFoodFacts');
+      }else{
+        toast('Продукт не найден в OpenFoodFacts. Введите данные вручную.');
+      }
+    }catch(err){
+      console.error('Ошибка загрузки данных продукта', err);
+      toast('Не удалось получить данные продукта. Попробуйте позже.', true);
+    }finally{
+      barcodeLookupInFlight = false;
       stopBarcode();
     }
   });


### PR DESCRIPTION
## Summary
- fetch OpenFoodFacts product data after successfully scanning a barcode
- populate the add-food form with the product name (including EAN) and its nutrition values
- guard against duplicate lookups, handle missing products, and stop scanning only after processing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6a74b2d008321b50b0cbb36990bda